### PR TITLE
Add Streamlit multiplication quiz skeleton

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,30 @@
-# Test your memory
-- multiplication
-- power of 2
-- sum
-- test?
+# Memory Trainer
+
+Prosty szkielet aplikacji Streamlit wspierającej trening tabliczki mnożenia.
+
+## Uruchamianie aplikacji
+
+1. Zainstaluj zależności:
+
+   ```bash
+   pip install -r requirements.txt
+   ```
+
+2. Uruchom serwer Streamlit:
+
+   ```bash
+   streamlit run app.py
+   ```
+
+3. W przeglądarce wpisz adres wyświetlony w terminalu (np. `http://localhost:8501`).
+
+Aplikacja losuje 10 zadań z mnożenia liczb z zakresu 2-12. Po wprowadzeniu odpowiedzi w formularzu
+naciśnij przycisk "Sprawdź odpowiedzi", aby zobaczyć wynik w formacie `poprawne/wszystkie`. Możesz również wylosować nowy zestaw pytań przyciskiem "Nowy zestaw pytań".
+
+## Testy
+
+Do sprawdzenia logiki aplikacji wykorzystano pytest. Uruchom wszystkie testy poleceniem:
+
+```bash
+pytest
+```

--- a/app.py
+++ b/app.py
@@ -1,0 +1,69 @@
+"""Streamlit UI for practicing multiplication tables."""
+
+from __future__ import annotations
+
+from typing import List, Optional
+
+import streamlit as st
+
+from memory_trainer import MultiplicationQuiz
+
+NUM_QUESTIONS = 10
+
+
+def _reset_quiz() -> None:
+    """Replace the active quiz with a fresh one and clear answers."""
+
+    st.session_state.quiz = MultiplicationQuiz.generate(NUM_QUESTIONS)
+    st.session_state.pop("score", None)
+    for index in range(NUM_QUESTIONS):
+        st.session_state.pop(f"answer_{index}", None)
+
+
+def _extract_answers(num_questions: int) -> List[Optional[int]]:
+    """Retrieve answers from ``st.session_state`` and coerce them to integers."""
+
+    answers: List[Optional[int]] = []
+    for index in range(num_questions):
+        raw_value = st.session_state.get(f"answer_{index}", "")
+        try:
+            answers.append(int(raw_value))
+        except (TypeError, ValueError):
+            answers.append(None)
+    return answers
+
+
+def main() -> None:
+    st.title("Trening tabliczki mnożenia")
+    st.write(
+        "Odpowiedz na 10 pytań dotyczących mnożenia liczb z zakresu 2-12, "
+        "a następnie sprawdź swój wynik."
+    )
+
+    if "quiz" not in st.session_state:
+        _reset_quiz()
+
+    quiz: MultiplicationQuiz = st.session_state.quiz
+
+    with st.form("multiplication_quiz"):
+        for index, question in enumerate(quiz.questions):
+            st.text_input(
+                label=f"Pytanie {index + 1}: {question.left} × {question.right} =",
+                key=f"answer_{index}",
+            )
+        submitted = st.form_submit_button("Sprawdź odpowiedzi")
+
+    if submitted:
+        answers = _extract_answers(len(quiz.questions))
+        st.session_state.score = quiz.grade(answers)
+
+    if "score" in st.session_state:
+        correct, total = st.session_state.score
+        st.success(f"Twój wynik: {correct}/{total}")
+
+    if st.button("Nowy zestaw pytań"):
+        _reset_quiz()
+
+
+if __name__ == "__main__":
+    main()

--- a/memory_trainer/__init__.py
+++ b/memory_trainer/__init__.py
@@ -1,0 +1,5 @@
+"""Core utilities for the memory trainer application."""
+
+from .quiz import MultiplicationQuestion, MultiplicationQuiz
+
+__all__ = ["MultiplicationQuestion", "MultiplicationQuiz"]

--- a/memory_trainer/quiz.py
+++ b/memory_trainer/quiz.py
@@ -1,0 +1,60 @@
+"""Utilities for creating and grading multiplication quizzes."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from random import Random
+from typing import List, Optional, Sequence, Tuple
+
+MIN_FACTOR = 2
+MAX_FACTOR = 12
+
+
+@dataclass(frozen=True)
+class MultiplicationQuestion:
+    """A single multiplication question."""
+
+    left: int
+    right: int
+
+    @property
+    def answer(self) -> int:
+        """Return the expected answer for the question."""
+
+        return self.left * self.right
+
+
+@dataclass
+class MultiplicationQuiz:
+    """A collection of multiplication questions with grading helpers."""
+
+    questions: List[MultiplicationQuestion]
+
+    @classmethod
+    def generate(
+        cls, num_questions: int = 10, rng: Optional[Random] = None
+    ) -> "MultiplicationQuiz":
+        """Return a quiz populated with random multiplication questions."""
+
+        if num_questions <= 0:
+            raise ValueError("num_questions must be a positive integer")
+
+        randomizer = rng or Random()
+        questions = [
+            MultiplicationQuestion(
+                randomizer.randint(MIN_FACTOR, MAX_FACTOR),
+                randomizer.randint(MIN_FACTOR, MAX_FACTOR),
+            )
+            for _ in range(num_questions)
+        ]
+        return cls(questions)
+
+    def grade(self, responses: Sequence[Optional[int]]) -> Tuple[int, int]:
+        """Return the number of correct answers and total number of questions."""
+
+        correct = 0
+        for index, question in enumerate(self.questions):
+            response = responses[index] if index < len(responses) else None
+            if response == question.answer:
+                correct += 1
+        return correct, len(self.questions)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+streamlit
+pytest

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,6 @@
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))

--- a/tests/test_quiz.py
+++ b/tests/test_quiz.py
@@ -1,0 +1,49 @@
+from random import Random
+
+import pytest
+
+from memory_trainer.quiz import (
+    MAX_FACTOR,
+    MIN_FACTOR,
+    MultiplicationQuestion,
+    MultiplicationQuiz,
+)
+
+
+def test_question_answer_property() -> None:
+    question = MultiplicationQuestion(3, 7)
+    assert question.answer == 21
+
+
+def test_generate_respects_range() -> None:
+    quiz = MultiplicationQuiz.generate(num_questions=10, rng=Random(123))
+
+    assert len(quiz.questions) == 10
+    for question in quiz.questions:
+        assert MIN_FACTOR <= question.left <= MAX_FACTOR
+        assert MIN_FACTOR <= question.right <= MAX_FACTOR
+
+
+def test_grade_counts_correct_answers() -> None:
+    quiz = MultiplicationQuiz(
+        [MultiplicationQuestion(2, 3), MultiplicationQuestion(4, 5)]
+    )
+
+    correct, total = quiz.grade([6, 21])
+
+    assert total == 2
+    assert correct == 1
+
+
+def test_grade_treats_non_numeric_as_incorrect() -> None:
+    quiz = MultiplicationQuiz([MultiplicationQuestion(2, 3)])
+
+    correct, total = quiz.grade([None])
+
+    assert total == 1
+    assert correct == 0
+
+
+def test_generate_requires_positive_number_of_questions() -> None:
+    with pytest.raises(ValueError):
+        MultiplicationQuiz.generate(num_questions=0)


### PR DESCRIPTION
## Summary
- add a Streamlit UI that serves ten random multiplication questions and reports the final score
- provide reusable quiz utilities for generating and grading multiplication tables
- cover the quiz logic with pytest-based unit tests and document how to run the app

## Testing
- `PYTHONDONTWRITEBYTECODE=1 pytest`


------
https://chatgpt.com/codex/tasks/task_e_68cf0ee417f08323aeec8db64bc05d0a