### PR TITLE
Fix clearing of current answer input after submissions

### DIFF
--- a/app.py
+++ b/app.py
@@ -15,7 +15,7 @@ def _reset_quiz() -> None:
     st.session_state.quiz = MultiplicationQuiz.generate(NUM_QUESTIONS)
     st.session_state.answers = [None] * len(st.session_state.quiz.questions)
     st.session_state.current_index = 0
-    st.session_state.current_answer = ""
+    st.session_state.pop("current_answer", None)
     st.session_state.pop("score", None)
 
 
@@ -66,7 +66,7 @@ def main() -> None:
                 st.session_state.answers[current_index] = None
 
             st.session_state.current_index = current_index + 1
-            st.session_state.current_answer = ""
+            st.session_state.pop("current_answer", None)
 
             if st.session_state.current_index == len(quiz.questions):
                 st.session_state.score = quiz.grade(st.session_state.answers)


### PR DESCRIPTION
## Summary
- avoid mutating the current answer widget state after it is created by clearing it with `pop`
- ensure quiz reset removes the stored answer so the text input reinitialises cleanly

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cf1a76a18883239d44dc6d5e4b4b05